### PR TITLE
Add rubycritic gem to ensure code quality

### DIFF
--- a/.rubycritic.yml
+++ b/.rubycritic.yml
@@ -1,0 +1,14 @@
+mode_ci:
+  enabled: true # default is false
+  branch: 'master' # default is master
+branch: 'master' # default is master
+path: # Set path where report will be saved (tmp/rubycritic by default)
+threshold_score: 10 # default is 0
+deduplicate_symlinks: true # default is false
+suppress_ratings: true # default is false
+no_browser: true # default is false
+formats: # Available values are: html, json, console, lint. Default value is html.
+  - console
+  - html
+minimum_score: 94.44 # default is 0
+paths: # Files to analyse.

--- a/heartcheck-activerecord.gemspec
+++ b/heartcheck-activerecord.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubycritic'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'yard'
 


### PR DESCRIPTION
## Motivation

Ensuring code quality to the project and then keep it always on a good level.

## Solution

In order to ensure code quality, the gem RubyCritic was added to the project as a development dependency.

The first run of analysis got 94.44 of score, sot it was kept as the minimum score on rubycritic configuration. This way we work to keep the quality always above it, and improving.

**Solution steps:**
- Add `rubycritic` gem dependency to gemspec file: `heartcheck-activerecord.gemspec`
- Add rubycritic configuration file: `.rubycritic.yml`
- Set configuration minimum score to `94.44`

## Print Screen

![image](https://user-images.githubusercontent.com/244181/137967819-ed743a2b-3530-4884-becb-a143cd657d28.png)

Branch `master`
![image](https://user-images.githubusercontent.com/244181/137968072-63fb31f0-809c-4c58-9f68-4fb2aa7e597e.png)

Branch `add_rubycritic_to_app`
![image](https://user-images.githubusercontent.com/244181/137968155-e52e9c01-646a-4e1d-ae3d-d119ecaccf7f.png)

This MR closes #4 
