### PR TITLE
Add support to activerecord 7.X.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased][]
+## [Unreleased][] - 19-03-2021
+### Added
+  - Support for `activerecord` 7.0 versions
 
 ## [0.1.2](https://github.com/locaweb/heartcheck-activerecord/compare/v0.1.1...v0.1.2) - 19-03-2021
 ### Added

--- a/heartcheck-activerecord.gemspec
+++ b/heartcheck-activerecord.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
 
-  spec.add_dependency 'activerecord', '>= 3.2'
+  spec.add_dependency 'activerecord', '>= 3.2', '< 8.0'
   spec.add_dependency 'heartcheck', '~> 2.0'
 
   spec.add_development_dependency 'pry-nav'

--- a/heartcheck-activerecord.gemspec
+++ b/heartcheck-activerecord.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
 
-  spec.add_dependency 'activerecord', '>= 3.2', '< 7.0'
+  spec.add_dependency 'activerecord', '>= 3.2'
   spec.add_dependency 'heartcheck', '~> 2.0'
 
   spec.add_development_dependency 'pry-nav'


### PR DESCRIPTION
### Motivation

It must be possible to use this dependency on a rails 7.x.x app.

### Solution
The version lock from activerecord was changed from 7.0 to 8.0.